### PR TITLE
Add option -n to support varnish instance names

### DIFF
--- a/check_varnish.py
+++ b/check_varnish.py
@@ -3,6 +3,7 @@
 #
 # Website : https://github.com/olivierHa/check_varnish
 # Copyright (C) 2015 : Olivier Hanesse olivier.hanesse@gmail.com
+# Modifications (C) 2017 : Claudio Kuenzler www.claudiokuenzler.com
 
 """Varnish Nagios check."""
 
@@ -16,12 +17,14 @@ import json
 class Varnish(nagiosplugin.Resource):
 
     def __init__(self, field):
-      self.field = field
-
+      self.field = args.arg_field
 
     def probe(self):
       try:
-        cmd = ['/usr/bin/varnishstat','-1','-j']
+        if args.arg_name:
+          cmd = ['/usr/bin/varnishstat','-1','-j','-n', args.arg_name]
+        else:
+          cmd = ['/usr/bin/varnishstat','-1','-j']
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
         output, unused_err = process.communicate()
         retcode = process.poll()
@@ -44,12 +47,13 @@ if __name__ == '__main__':
                       help='return warning if value is outside RANGE')
     argp.add_argument('-c', '--critical', metavar='RANGE', default='',
                       help='return critical if value is outside RANGE')
-    argp.add_argument('-f', '--field', metavar='FIELD', action='store', default='MAIN.sess_dropped',
+    argp.add_argument('-f', '--field', metavar='FIELD', dest='arg_field', required=True, action='store', default='MAIN.sess_dropped',
                       help='field to query')
+    argp.add_argument('-n', '--name', metavar='NAME', dest='arg_name', action='store', default='',
+                      help='name of Varnish instance (optional)')
     args = argp.parse_args()
 
     check = nagiosplugin.Check(
-        Varnish(args.field),
+        Varnish(args.arg_field),
         nagiosplugin.ScalarContext('varnish', args.warning, args.critical))
     check.main()
-


### PR DESCRIPTION
The modifications allow to use the plugin on Varnish installations with named instance/work dir with the optional "-n" parameter. 

    # ./check_varnish_new.py -f MAIN.cache_miss -n varnish-titan
    VARNISH OK - MAIN.cache_miss is 683744
    | 'MAIN.cache_miss'=683744

Other minor change: -f parameter is mandatory and an error is reported by argparse if the user missed to define -f