### PR TITLE
Add Cache Hit Rate calculation

### DIFF
--- a/check_varnish.py
+++ b/check_varnish.py
@@ -104,6 +104,11 @@ def check():
       for key in keys:
         multiout += "{} is {} - " .format(keys[x], values[x])
         multiperfdata += "{}={};{};{};; " .format(keys[x], values[x], warning, critical)
+        if hitratio:
+          if key in 'MAIN.cache_hit':
+            hitvalue = float(values[x])
+          if key in 'MAIN.cache_miss':
+            missvalue = float(values[x])
         x+=1
       if hitratio and hitvalue > 0:
         #print(hitvalue)  # Debug


### PR DESCRIPTION
This PR adds a new parameter (`-r` / `--hitratio`). This tells the check_haproxy plugin to calculate the Cache Hit Rate. 

```
# ./check_varnish.py -n varnish-instance -f MAIN.cache_hit,MAIN.cache_miss -r
VARNISH OK - MAIN.cache_hit is 41854430 - MAIN.cache_miss is 32586870 - Cache Hit Rate is 0.56 -  | MAIN.cache_hit=41854430;0;0;; MAIN.cache_miss=32586870;0;0;; hitrate=0.56;0;0;; 
```