### PR TITLE
fix for newer Varnish versions with changed varnishst…

### DIFF
--- a/check_varnish.py
+++ b/check_varnish.py
@@ -135,7 +135,7 @@ def check():
 # ----------------------------------------------------------------------
 
 def getopts():
-    global fields,instance,hitratio,varnishversion,warning,critical
+    global fields,instance,hitratio,warning,critical
     argp = argparse.ArgumentParser(description=__doc__)
     argp.add_argument('-w', '--warning', metavar='RANGE', dest='arg_warning', default=0,
                       help='return warning if value is outside RANGE')

--- a/check_varnish.py
+++ b/check_varnish.py
@@ -29,6 +29,7 @@
 # 1.4 Jun 24, 2022: Fix exit code when threshold check is OK
 # 1.5 Jan 9, 2023: Add Cache Hit Rate calculation (-r / --hitrate)
 # 1.6 Aug 22, 2023: Support new varnishstat output (counters) for Varnish >= 6.5.0 (-v / --version)
+# 1.7 Jun 3, 2024: Bugfix in Varnish version check (only supports major.minor format now, e.g. 6.5)
 
 """Varnish Monitoring check."""
 
@@ -72,7 +73,7 @@ def check():
   for field in fields:
     #print(field) # Debug
     keys.append(field)
-    if varnishversion >= 650:
+    if varnishversion >= 65:
       #print(json_data['counters'][field]['value']) # Debug
       values.append(json_data['counters'][field]['value'])
     else:
@@ -142,9 +143,13 @@ def getopts():
                       help='name of Varnish instance (optional)')
     argp.add_argument('-r', '--hitratio', dest='arg_hitratio', action='store_true', default=False,
                       help='calculate cache hit ratio (optional)')
-    argp.add_argument('-v', '--version', metavar='VERSION', dest='arg_version', action='store', default=600,
-                      help='define Varnish version (varnishstat output changed with Varnish 6.5.0+')
+    argp.add_argument('-v', '--version', metavar='VERSION', dest='arg_version', action='store', default=60,
+                      help='define Varnish version (only major.minor version, without bugfix releases), example: 6.0 (varnishstat output changed with Varnish 6.5+')
     args = argp.parse_args()
+
+    if args.arg_version.count('.') >= 2:
+        print("VARNISH UNKNOWN - Must use version in format major.minor, example: 6.5")
+        sys.exit(3)
 
     fields=args.arg_field.split(',')
     instance=args.arg_name

--- a/check_varnish.py
+++ b/check_varnish.py
@@ -5,7 +5,7 @@
 # Official repository : https://github.com/olivierHa/check_varnish
 #
 # Copyright (C) 2015 Olivier Hanesse olivier.hanesse@gmail.com
-# Copyright (C) 2017,2020,2022,2023 Claudio Kuenzler www.claudiokuenzler.com
+# Copyright (C) 2017,2020,2022,2023,2024 Claudio Kuenzler www.claudiokuenzler.com
 #
 # Licence:      GNU General Public Licence (GPL) http://www.gnu.org/
 # This program is free software; you can redistribute it and/or
@@ -30,6 +30,7 @@
 # 1.5 Jan 9, 2023: Add Cache Hit Rate calculation (-r / --hitrate)
 # 1.6 Aug 22, 2023: Support new varnishstat output (counters) for Varnish >= 6.5.0 (-v / --version)
 # 1.7 Jun 3, 2024: Bugfix in Varnish version check (only supports major.minor format now, e.g. 6.5)
+# 1.8 Jun 21, 2024: Improve Varnish version detection (automatic), remove -v/--version parameter
 
 """Varnish Monitoring check."""
 
@@ -69,6 +70,10 @@ def check():
     sys.exit(2)
 
   json_data = json.loads(output)
+
+  # Detect newer Varnish versions (6.5+)
+  if "version" in json_data:
+    varnishversion = 65
 
   for field in fields:
     #print(field) # Debug
@@ -143,18 +148,11 @@ def getopts():
                       help='name of Varnish instance (optional)')
     argp.add_argument('-r', '--hitratio', dest='arg_hitratio', action='store_true', default=False,
                       help='calculate cache hit ratio (optional)')
-    argp.add_argument('-v', '--version', metavar='VERSION', dest='arg_version', action='store', default=60,
-                      help='define Varnish version (only major.minor version, without bugfix releases), example: 6.0 (varnishstat output changed with Varnish 6.5+')
     args = argp.parse_args()
-
-    if args.arg_version.count('.') >= 2:
-        print("VARNISH UNKNOWN - Must use version in format major.minor, example: 6.5")
-        sys.exit(3)
 
     fields=args.arg_field.split(',')
     instance=args.arg_name
     hitratio=args.arg_hitratio
-    varnishversion=int(args.arg_version.replace(".",""))
     warning=int(args.arg_warning)
     critical=int(args.arg_critical)
 


### PR DESCRIPTION
Varnish 6.5.0 added a change in the varnishstat output. The keys and values are now nested within an additional "counters" element. 

https://github.com/varnishcache/varnish-cache/blob/master/doc/changes.rst:

> All counters have been moved down one level to the counters object.


This is a quick and dirty workaround that you can use `-v` or `--version` to enter the Varnish version used. 
Much better would be a way that the plugin looks up the installed Varnish version independently. 